### PR TITLE
Fix use of __doc__ in setup.py for -OO mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ For older changes, see
 
 from setuptools import setup, find_packages
 
-doclines = __doc__.splitlines()
+# Docstring may not be present in optimized Python run mode, so if the
+# docstring is missing just use empty strings so install still works
+doclines = (__doc__ or '').splitlines() or ['', '']
 
 setup(name="python-card-me",
       version="0.9.3",


### PR DESCRIPTION
Currently setup will fail when using `pip install python-card-me` if the `-OO` flag is used (also enabled via `PYTHONOPTIMIZE=2`) because docstrings are stripped (which is the point of that mode).

Very minor change that allows the docstring to be missing for this case and install to work as expected.

EDIT: Actually I had to tweak things for this setup.py a tiny bit (this is a boilerplate PR, a lot of projects do the `__doc__.splitlines()`) since setup.py expects there to be a list as a result. Different way to accomplish the same thing is fine by me, just looking for the end result of allowing install when the docstrings are stripped.
