### PR TITLE
Add Python version classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,11 @@ setup(name="python-card-me",
           Intended Audience :: Developers
           Natural Language :: English
           Programming Language :: Python
+          Programming Language :: Python :: 2
+          Programming Language :: Python :: 2.7
+          Programming Language :: Python :: 3
+          Programming Language :: Python :: 3.4
+          Programming Language :: Python :: 3.5
           Operating System :: OS Independent
           Topic :: Text Processing""".strip().splitlines()
       )


### PR DESCRIPTION
Add specific version classifiers to setup.py so that the package is correctly marked as supporting Python3 when using sites like [caniusepython3.com](https://caniusepython3.com/project/python-card-me).